### PR TITLE
Created state to hide component on delete

### DIFF
--- a/components/blog/details.tsx
+++ b/components/blog/details.tsx
@@ -1,91 +1,87 @@
 "use client";
-import React, { useState } from 'react';
-import Link from 'next/link';
-import styles from './details.module.scss';
+import React, { useState } from "react";
+import Link from "next/link";
+import styles from "./details.module.scss";
 import { useRouter } from "next/navigation";
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { set } from "zod";
 
 interface Props {
   id: string;
   date: string;
+  setPostDeleted: React.Dispatch<React.SetStateAction<boolean>>;
   author?: string;
 }
 
 function Details(props: Props) {
-	const { id, date, author } = props;
-	const [deleteMessage, setDeleteMessage] = useState(false);
-	const [deleteSuccess, setDeleteSuccess] = useState(false);
-	const router = useRouter();
+  const { id, date, author, setPostDeleted } = props;
+  const [deleteMessage, setDeleteMessage] = useState(false);
+  const [deleteSuccess, setDeleteSuccess] = useState(false);
+  const router = useRouter();
 
-	const deletePost = async () => {
-		const supabase = createClientComponentClient()
+  const deletePost = async () => {
+    const supabase = createClientComponentClient();
 
-		try {
-		const { error } = await supabase
-				.from('posts')
-				.delete()
-				.eq('id', id)
-		if(!error) {
-			router.refresh();
-			setDeleteMessage(false);
-		}
-		} catch (error) {
-			console.error(error);
-		}
-	};
+    try {
+      const { error } = await supabase.from("posts").delete().eq("id", id);
+      if (error) {
+        throw error;
+      }
+      setPostDeleted(true);
+    } catch (error) {
+      console.error(error);
+    }
+  };
 
-	const toggleDeleteMessage = () => {
-		setDeleteMessage(!deleteMessage);
-	};
+  function handleRefresh() {
+    router.refresh();
+  }
 
-	const fullDate = new Date(date);
-	const month = fullDate.getUTCMonth() + 1;
-	const day = fullDate.getUTCDate();
-	const year = fullDate.getUTCFullYear();
-	const parsedDate = `${month}/${day}/${year}`;
-	return (
-		deleteSuccess ? <div style={{ color: 'red', fontSize: 14 }}>Post Deleted</div> : (
-			<div className={styles.container}>
-				<ul>
-					{deleteMessage ? (
-						<div className={styles.deleteContainer}>
-							<li>Are you sure?</li>
-							<div>
-								<li onClick={deletePost}>
-									Yes
-								</li>
-								<li onClick={toggleDeleteMessage}>
-									No
-								</li>
-							</div>
-						</div>
-					) : (
-						<li className={styles.deleteButton} onClick={toggleDeleteMessage}>
-							Delete
-						</li>
-					)}
-					<li className={styles.editButton}>
-						<Link href={`/blog/edit/${id}`}>
-							Edit
-						</Link>
-					</li>
-					{author
-					&& (
-						<li>
-							<span>
-								Written by <span>{author}</span>
-							</span>
-						</li>
-					)}
-					<li>
-						<span>
-							Posted on <span>{parsedDate}</span>
-						</span>
-					</li>
-				</ul>
-			</div>
-		)
-	);
+  const toggleDeleteMessage = () => {
+    setDeleteMessage(!deleteMessage);
+  };
+
+  const fullDate = new Date(date);
+  const month = fullDate.getUTCMonth() + 1;
+  const day = fullDate.getUTCDate();
+  const year = fullDate.getUTCFullYear();
+  const parsedDate = `${month}/${day}/${year}`;
+  return deleteSuccess ? (
+    <div style={{ color: "red", fontSize: 14 }}>Post Deleted</div>
+  ) : (
+    <div className={styles.container}>
+      <ul>
+        {deleteMessage ? (
+          <div className={styles.deleteContainer}>
+            <li>Are you sure?</li>
+            <div>
+              <li onClick={deletePost}>Yes</li>
+              <li onClick={toggleDeleteMessage}>No</li>
+            </div>
+          </div>
+        ) : (
+          <li className={styles.deleteButton} onClick={toggleDeleteMessage}>
+            Delete
+          </li>
+        )}
+        <li className={styles.editButton}>
+          <Link href={`/blog/edit/${id}`}>Edit</Link>
+        </li>
+        {author && (
+          <li>
+            <span>
+              Written by <span>{author}</span>
+            </span>
+          </li>
+        )}
+        <li>
+          <span>
+            Posted on <span>{parsedDate}</span>
+          </span>
+        </li>
+      </ul>
+    </div>
+  );
 }
 
 export default Details;

--- a/components/blog/post.tsx
+++ b/components/blog/post.tsx
@@ -10,6 +10,7 @@ function Post({ post }: { post: any }) {
   const { id, title, image, first_paragraph, created_at } = post;
   const supabase = createClientComponentClient();
   const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [postDeleted, setPostDeleted] = useState<boolean>(false);
 
   useEffect(() => {
     if (image) downloadImage(image);
@@ -36,6 +37,10 @@ function Post({ post }: { post: any }) {
       postTitle = `${postTitle.slice(0, 70)}...`;
     }
     return postTitle;
+  }
+
+  if (postDeleted) {
+    return <div style={{ display: "none" }}></div>;
   }
 
   return (
@@ -70,7 +75,7 @@ function Post({ post }: { post: any }) {
           </Link>
         </h3>
         {first_paragraph}
-        <Details id={id} date={created_at} />
+        <Details id={id} date={created_at} setPostDeleted={setPostDeleted} />
       </div>
     </div>
   );


### PR DESCRIPTION
The `useRouter()` hook isn't properly refreshing the page on deletion of a post, even though the original fetch is set to `no-cache`. To handle removing the post component on the client side, a piece of state now switches the post to a div with `display: hidden` to remove it from view. 