### PR TITLE
Fixed update post

### DIFF
--- a/app/blog/edit/[id]/page.tsx
+++ b/app/blog/edit/[id]/page.tsx
@@ -163,6 +163,8 @@ function EditPost() {
         imagePath = imageUrl
           ? await replaceCurrentImage(imageUrl, file)
           : await uploadNewImage(file);
+      } else {
+        imagePath = imageUrl;
       }
 
       // attempt to update post
@@ -212,10 +214,9 @@ function EditPost() {
   async function replaceCurrentImage(filePath: string, file: File) {
     try {
       // Remove old image
-      // TODO: Why is filePath not being used?
       const { error } = await supabase.storage
         .from("images")
-        .remove([imageUrl!]);
+        .remove([filePath]);
 
       if (error) {
         throw error;


### PR DESCRIPTION
Fixed an error where the post image URI would be lost if the post was updated without changing the image.

The replace function now uses the parameter passed in instead of the state variable.